### PR TITLE
Allow api-service to send full fetch response even when the response …

### DIFF
--- a/src/client/utils/api-service.ts
+++ b/src/client/utils/api-service.ts
@@ -22,9 +22,9 @@ export const api = async <T = any>(uri: string, method: string = 'GET', body?: {
     try {
         const res = await fetch(uri, options)    
         if (res.ok) {
-            return <T><unknown>(await res)
+            return <T><unknown>(res);
         } else {
-            return res.status;
+            return <T><unknown>(res);
         }
     } catch (e) {
         console.log(e);

--- a/src/client/views/auth/Login.tsx
+++ b/src/client/views/auth/Login.tsx
@@ -33,6 +33,7 @@ const Login = () => {
                 }
             } else {
                 alert('Incorrect or nonexistant credentials provided.');
+                alert(await login.json());
             }
 
         } catch (e) {

--- a/src/client/views/auth/Register.tsx
+++ b/src/client/views/auth/Register.tsx
@@ -33,7 +33,8 @@ const Login = () => {
                 alert('Registration successful!')
                 history.replace('/login');
             } else {
-                alert('There was an error with registration, please ensure all mandatory fields are filled out.')
+                alert('There was an error with registration, please ensure all mandatory fields are filled out.');
+                alert(await register.json());
             }
         } catch (e) {
             console.log(e);

--- a/src/client/views/blogs/AllBlogs.tsx
+++ b/src/client/views/blogs/AllBlogs.tsx
@@ -12,7 +12,6 @@ const AllBlogs = () => {
             try {
                 const blogs = await api('/api/blogs');
                 const blogRes = await blogs.json();
-                // console.log(blogRes);
                 updateBlogs(blogRes);
             } catch (e) {
                 console.log(e);

--- a/src/client/views/stripe/DonateForm.tsx
+++ b/src/client/views/stripe/DonateForm.tsx
@@ -28,14 +28,7 @@ const DonateForm = (props: IDonateFormProps) => {
     }
 
     const charge = { token, amount };
-
-    // using default browser fetch instead of my api helper fetch, since that only returns the status
-    // code for not okay responses and I want to use the actual error JSON reponses for meaningful SWAL2 errors
-    const response = await fetch('/stripe/charge', {
-      method: 'POST', 
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(charge)
-    });
+    const response = await api('/stripe/charge', 'POST', charge);
 
     if (response.ok) {
       const session = await response.json();


### PR DESCRIPTION
…is bad, so that we can provide good error handling on the frontend; allowed frontend components to receive the data they awaited on for bad responses